### PR TITLE
Fix mobile header overflow

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,10 +31,10 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
   };
 
   return (
-    <motion.header 
+    <motion.header
       initial={{ y: -100 }}
       animate={{ y: 0 }}
-      className="fixed top-0 left-0 right-0 z-50 bg-gray-900/90 dark:bg-gray-900/90 backdrop-blur-lg border-b border-gray-800/50"
+      className="fixed top-0 left-0 right-0 z-50 w-full overflow-x-hidden bg-gray-900/90 dark:bg-gray-900/90 backdrop-blur-lg border-b border-gray-800/50"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
## Summary
- prevent header overflow on mobile by constraining width and hiding overflow
- ensure html also hides horizontal overflow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865655088408324ab50bcd48346b968