### PR TITLE
Add automatic dark mode detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script>
+      (function () {
+        const stored = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored ? stored === 'dark' : prefersDark) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-900">
+      <div className="min-h-screen flex items-center justify-center bg-white text-gray-900 dark:bg-gray-900 dark:text-white">
         <div className="text-center">
           <motion.div
             initial={{ scale: 0 }}
@@ -85,7 +85,7 @@ function App() {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.5 }}
-        className="min-h-screen bg-gray-900 text-white"
+        className="min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-white"
       >
         <Header activeSection={activeSection} setActiveSection={setActiveSection} />
         

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,13 +1,30 @@
 import { useState, useEffect } from 'react';
 
 export const useTheme = () => {
-  const [isDark, setIsDark] = useState(() => {
+  const getPreferredTheme = () => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('theme');
-      return stored ? stored === 'dark' : true; // Default to dark theme
+      if (stored) {
+        return stored === 'dark';
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches;
     }
     return true;
-  });
+  };
+
+  const [isDark, setIsDark] = useState(getPreferredTheme);
+
+  useEffect(() => {
+    const matcher = window.matchMedia('(prefers-color-scheme: dark)');
+    const systemChange = (e: MediaQueryListEvent) => {
+      const stored = localStorage.getItem('theme');
+      if (!stored) {
+        setIsDark(e.matches);
+      }
+    };
+    matcher.addEventListener('change', systemChange);
+    return () => matcher.removeEventListener('change', systemChange);
+  }, []);
 
   useEffect(() => {
     localStorage.setItem('theme', isDark ? 'dark' : 'light');


### PR DESCRIPTION
## Summary
- support loading theme from system preference
- initialize dark mode early in `index.html`
- make site backgrounds aware of dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68657964556c8324a58173fc2aa55cb9