### PR TITLE
Enhance skills layout and hover effect

### DIFF
--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -61,7 +61,7 @@ const Skills: React.FC = () => {
                 </div>
 
                 {/* Skills Grid */}
-                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 place-items-center">
                   {categorySkills.map((skill, skillIndex) => {
                     const IconComponent = getIconComponent(skill.icon);
 
@@ -74,7 +74,7 @@ const Skills: React.FC = () => {
                           duration: 0.4,
                           delay: categoryIndex * 0.1 + skillIndex * 0.05
                         }}
-                        className="group relative flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-xl p-6 h-32 backdrop-blur-sm hover:border-blue-500/30 transition-all duration-300"
+                        className="skill-card group relative flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-gray-900/50 to-gray-800/50 border border-gray-700/50 rounded-xl p-6 h-32 backdrop-blur-sm hover:border-blue-500/30 transition-all duration-300"
                       >
                         <div className="p-3 bg-gradient-to-r from-blue-500/20 to-purple-500/20 rounded-lg">
                           <IconComponent className="text-blue-400 group-hover:text-white transition-colors" size={28} />
@@ -84,7 +84,7 @@ const Skills: React.FC = () => {
                           {skill.name}
                         </h4>
 
-                        <div className="absolute inset-0 rounded-xl bg-gradient-to-r from-blue-500/5 to-purple-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                        <div className="shine-effect absolute inset-0 rounded-xl pointer-events-none"></div>
                       </motion.div>
                     );
                   })}

--- a/src/index.css
+++ b/src/index.css
@@ -200,3 +200,38 @@ textarea:focus-visible {
     color: #000000;
   }
 }
+
+/* Skill card shine effect */
+.skill-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.skill-card .shine-effect {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    rgba(59, 130, 246, 0) 0%,
+    rgba(59, 130, 246, 0.3) 25%,
+    rgba(139, 92, 246, 0.3) 50%,
+    rgba(236, 72, 153, 0.3) 75%,
+    rgba(236, 72, 153, 0) 100%
+  );
+  background-size: 200% 100%;
+  opacity: 0;
+  transform: translateX(-100%);
+  transition: opacity 0.3s ease;
+}
+
+.skill-card:hover .shine-effect {
+  opacity: 1;
+  animation: shine 0.8s linear forwards;
+}
+
+@keyframes shine {
+  to {
+    transform: translateX(100%);
+  }
+}


### PR DESCRIPTION
## Summary
- center skills grid items
- add colorful shine animation on hover

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686582c3ba948324a96e47e62c440ccb