### PR TITLE
Improve light theme text palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         if (stored ? stored === 'dark' : prefersDark) {
           document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.add('light');
         }
       })();
     </script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-white text-gray-900 dark:bg-gray-900 dark:text-white">
+      <div className="min-h-screen flex items-center justify-center bg-slate-50 text-gray-900 dark:bg-gray-900 dark:text-white">
         <div className="text-center">
           <motion.div
             initial={{ scale: 0 }}
@@ -85,7 +85,7 @@ function App() {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.5 }}
-        className="min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-white"
+        className="min-h-screen bg-slate-50 text-gray-900 dark:bg-gray-900 dark:text-white"
       >
         <Header activeSection={activeSection} setActiveSection={setActiveSection} />
         

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -122,7 +122,7 @@ const Contact: React.FC = () => {
               Trabajemos Juntos
             </span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+          <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mx-auto">
             ¿Listo para dar vida a tus ideas? Ponte en contacto y creemos algo increíble juntos.
           </p>
         </motion.div>
@@ -136,8 +136,8 @@ const Contact: React.FC = () => {
             className="space-y-8"
           >
             <div>
-              <h3 className="text-2xl font-bold text-white mb-6">Ponte en Contacto</h3>
-              <p className="text-gray-400 mb-8">
+              <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">Ponte en Contacto</h3>
+              <p className="text-gray-600 dark:text-gray-400 mb-8">
                 Siempre estoy abierto a discutir nuevas oportunidades, proyectos creativos o posibles colaboraciones.
                 Ya sea que tengas un proyecto específico en mente o simplemente quieras explorar posibilidades, me encantaría saber de ti.
               </p>
@@ -160,8 +160,8 @@ const Contact: React.FC = () => {
                     <contact.icon className="text-purple-400 group-hover:text-white transition-colors" size={24} />
                   </div>
                   <div>
-                    <div className="text-gray-400 text-sm">{contact.label}</div>
-                    <div className="text-white font-medium group-hover:text-purple-400 transition-colors">
+                    <div className="text-gray-600 dark:text-gray-400 text-sm">{contact.label}</div>
+                    <div className="text-gray-900 dark:text-white font-medium group-hover:text-purple-400 transition-colors">
                       {contact.value}
                     </div>
                   </div>
@@ -180,7 +180,7 @@ const Contact: React.FC = () => {
                 <div className="w-3 h-3 bg-green-400 rounded-full animate-pulse"></div>
                 <span className="text-green-400 font-medium">Disponible para nuevos proyectos</span>
               </div>
-              <p className="text-gray-400 text-sm">
+              <p className="text-gray-600 dark:text-gray-400 text-sm">
                 Actualmente acepto nuevos clientes y oportunidades emocionantes. Tiempo medio de respuesta: 24 horas.
               </p>
             </motion.div>
@@ -196,7 +196,7 @@ const Contact: React.FC = () => {
             <form onSubmit={handleSubmit} className="space-y-6">
               {/* Name Field */}
               <div>
-                <label htmlFor="name" className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   Nombre Completo *
                 </label>
                 <input
@@ -220,7 +220,7 @@ const Contact: React.FC = () => {
 
               {/* Email Field */}
               <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   Correo Electrónico *
                 </label>
                 <input
@@ -244,7 +244,7 @@ const Contact: React.FC = () => {
 
               {/* Subject Field */}
               <div>
-                <label htmlFor="subject" className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="subject" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   Asunto *
                 </label>
                 <input
@@ -268,7 +268,7 @@ const Contact: React.FC = () => {
 
               {/* Message Field */}
               <div>
-                <label htmlFor="message" className="block text-sm font-medium text-gray-300 mb-2">
+                <label htmlFor="message" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   Mensaje *
                 </label>
                 <textarea

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -25,7 +25,7 @@ const Education: React.FC = () => {
               Educación y Certificaciones
             </span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+          <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mx-auto">
             Aprendizaje continuo y desarrollo profesional mediante educación formal y certificaciones de la industria
           </p>
         </motion.div>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -25,7 +25,7 @@ const Experience: React.FC = () => {
               Experiencia Profesional
             </span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+          <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mx-auto">
             Un recorrido por experiencias y proyectos donde aplico visión empresarial, pensamiento creativo y desarrollo tecnológico para impulsar soluciones con impacto real.
           </p>
         </motion.div>
@@ -120,7 +120,7 @@ const Experience: React.FC = () => {
               <div className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent mb-2">
                 {stat.number}
               </div>
-              <div className="text-gray-400 text-sm">{stat.label}</div>
+              <div className="text-gray-600 dark:text-gray-400 text-sm">{stat.label}</div>
             </div>
           ))}
         </motion.div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,7 +34,11 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
     <motion.header
       initial={{ y: -100 }}
       animate={{ y: 0 }}
-      className="fixed top-0 left-0 right-0 z-50 w-full overflow-x-hidden bg-gray-900/90 dark:bg-gray-900/90 backdrop-blur-lg border-b border-gray-800/50"
+      className={`fixed top-0 left-0 right-0 z-50 w-full overflow-x-hidden backdrop-blur-lg border-b ${
+        isDark
+          ? 'bg-gray-900/90 border-gray-800/50'
+          : 'bg-white/90 border-gray-200/50'
+      }`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
@@ -53,9 +57,13 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
                 key={section.id}
                 onClick={() => scrollToSection(section.id)}
                 className={`text-sm font-medium transition-colors duration-200 ${
-                  activeSection === section.id 
-                    ? 'text-blue-400' 
-                    : 'text-gray-300 hover:text-white'
+                  activeSection === section.id
+                    ? isDark
+                      ? 'text-blue-400'
+                      : 'text-blue-600'
+                    : isDark
+                      ? 'text-gray-300 hover:text-white'
+                      : 'text-gray-700 hover:text-black'
                 }`}
               >
                 {section.label}
@@ -66,18 +74,31 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
           {/* Theme Toggle & Mobile Menu */}
           <div className="flex items-center space-x-4">
             <motion.button
-              whileHover={{ scale: 1.1 }}
+              whileHover={{ scale: 1.1, rotate: 15 }}
               whileTap={{ scale: 0.9 }}
               onClick={toggleTheme}
-              className="p-2 rounded-lg bg-gray-800 text-gray-300 hover:text-white transition-colors"
+              className={`p-2 rounded-lg transition-colors ${
+                isDark
+                  ? 'bg-gray-800 text-gray-300 hover:text-white'
+                  : 'bg-gray-200 text-gray-600 hover:text-gray-900'
+              }`}
             >
-              {isDark ? <Sun size={18} /> : <Moon size={18} />}
+              <motion.span
+                animate={{ rotate: isDark ? 0 : 180 }}
+                transition={{ duration: 0.3 }}
+              >
+                {isDark ? <Sun size={18} /> : <Moon size={18} />}
+              </motion.span>
             </motion.button>
 
             {/* Mobile Menu Button */}
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="md:hidden p-2 rounded-lg bg-gray-800 text-gray-300 hover:text-white transition-colors"
+              className={`md:hidden p-2 rounded-lg transition-colors ${
+                isDark
+                  ? 'bg-gray-800 text-gray-300 hover:text-white'
+                  : 'bg-gray-200 text-gray-600 hover:text-gray-900'
+              }`}
             >
               {mobileMenuOpen ? <X size={18} /> : <Menu size={18} />}
             </button>
@@ -86,20 +107,24 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
 
         {/* Mobile Navigation */}
         {mobileMenuOpen && (
-          <motion.nav 
+          <motion.nav
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="md:hidden py-4 border-t border-gray-800/50"
+            className={`md:hidden py-4 border-t ${isDark ? 'border-gray-800/50' : 'border-gray-200/50'}`}
           >
             {sections.map((section) => (
               <button
                 key={section.id}
                 onClick={() => scrollToSection(section.id)}
                 className={`block w-full text-left py-2 px-4 text-sm font-medium transition-colors duration-200 ${
-                  activeSection === section.id 
-                    ? 'text-blue-400 bg-gray-800/50' 
-                    : 'text-gray-300 hover:text-white hover:bg-gray-800/30'
+                  activeSection === section.id
+                    ? isDark
+                      ? 'text-blue-400 bg-gray-800/50'
+                      : 'text-blue-600 bg-gray-100'
+                    : isDark
+                      ? 'text-gray-300 hover:text-white hover:bg-gray-800/30'
+                      : 'text-gray-700 hover:text-black hover:bg-gray-100'
                 }`}
               >
                 {section.label}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -61,7 +61,7 @@ const Hero: React.FC = () => {
               className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-blue-500/10 to-purple-500/10 rounded-full border border-blue-500/20 mb-6"
             >
               <div className="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></div>
-              <span className="text-sm text-gray-300">Disponible para trabajar</span>
+              <span className="text-sm text-gray-700 dark:text-gray-300">Disponible para trabajar</span>
             </motion.div>
 
             {/* Name */}
@@ -81,12 +81,12 @@ const Hero: React.FC = () => {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.4 }}
-              className="text-xl sm:text-2xl lg:text-3xl font-medium text-gray-300 mb-6"
+              className="text-xl sm:text-2xl lg:text-3xl font-medium text-gray-700 dark:text-gray-300 mb-6"
             >
               <span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
                 Creative Business Designer
               </span>
-              <span className="text-gray-400"> & </span>
+              <span className="text-gray-500 dark:text-gray-400"> & </span>
               <span className="bg-gradient-to-r from-purple-400 to-red-400 bg-clip-text text-transparent">
                 Solutions Developer
               </span>
@@ -97,7 +97,7 @@ const Hero: React.FC = () => {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.5 }}
-              className="text-lg text-gray-400 mb-8 max-w-2xl"
+              className="text-lg text-gray-600 dark:text-gray-400 mb-8 max-w-2xl"
             >
               Impulsando la mejora empresarial mediante programación, 
               soluciones creativas y tecnología aplicada; optimizando 
@@ -129,7 +129,7 @@ const Hero: React.FC = () => {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.7 }}
-              className="flex flex-wrap items-center justify-center lg:justify-start gap-6 mb-8 text-gray-400"
+              className="flex flex-wrap items-center justify-center lg:justify-start gap-6 mb-8 text-gray-600 dark:text-gray-400"
             >
               <div className="flex items-center gap-2">
                 <MapPin size={16} />

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -50,7 +50,7 @@ const Portfolio: React.FC = () => {
               Portafolio Destacado
             </span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+          <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mx-auto">
             Una muestra de proyectos innovadores que abarcan desarrollo web, aplicaciones móviles, visualización 3D y medios creativos
           </p>
         </motion.div>
@@ -180,7 +180,7 @@ const Portfolio: React.FC = () => {
           transition={{ duration: 0.6, delay: 0.6 }}
           className="text-center mt-12"
         >
-          <p className="text-gray-400 mb-6">
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
             ¿Interesado en ver más de mi trabajo?
           </p>
           <a

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -36,7 +36,7 @@ const Skills: React.FC = () => {
               Habilidades y Experiencia
             </span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+          <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl mx-auto">
             Un conjunto completo de herramientas que abarca desarrollo full-stack, diseño creativo y tecnologías emergentes
           </p>
         </motion.div>
@@ -106,25 +106,25 @@ const Skills: React.FC = () => {
               <div className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent mb-2">
                 20+
               </div>
-              <div className="text-gray-400 text-sm">Tecnologías</div>
+              <div className="text-gray-600 dark:text-gray-400 text-sm">Tecnologías</div>
             </div>
             <div className="text-center">
               <div className="text-3xl font-bold bg-gradient-to-r from-purple-400 to-red-400 bg-clip-text text-transparent mb-2">
                 5+
               </div>
-              <div className="text-gray-400 text-sm">Años de Experiencia</div>
+              <div className="text-gray-600 dark:text-gray-400 text-sm">Años de Experiencia</div>
             </div>
             <div className="text-center">
               <div className="text-3xl font-bold bg-gradient-to-r from-red-400 to-blue-400 bg-clip-text text-transparent mb-2">
                 6
               </div>
-              <div className="text-gray-400 text-sm">Categorías de Habilidades</div>
+              <div className="text-gray-600 dark:text-gray-400 text-sm">Categorías de Habilidades</div>
             </div>
             <div className="text-center">
               <div className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-red-400 bg-clip-text text-transparent mb-2">
                 90%
               </div>
-              <div className="text-gray-400 text-sm">Promedio de Dominio</div>
+              <div className="text-gray-600 dark:text-gray-400 text-sm">Promedio de Dominio</div>
             </div>
           </div>
         </motion.div>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -27,11 +27,14 @@ export const useTheme = () => {
   }, []);
 
   useEffect(() => {
+    const root = document.documentElement;
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
     if (isDark) {
-      document.documentElement.classList.add('dark');
+      root.classList.add('dark');
+      root.classList.remove('light');
     } else {
-      document.documentElement.classList.remove('dark');
+      root.classList.add('light');
+      root.classList.remove('dark');
     }
   }, [isDark]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -15,12 +15,17 @@ html {
 
 body {
   font-family: 'Inter', sans-serif;
-  background: #0a0a0a;
-  color: #ffffff;
+  background: #f7f8fc;
+  color: #1e293b;
   margin: 0;
   padding: 0;
   min-height: 100vh;
   overflow-x: hidden;
+}
+
+.dark body {
+  background: #0a0a0a;
+  color: #ffffff;
 }
 
 /* Prevent horizontal scroll from transformed elements */
@@ -34,6 +39,10 @@ section {
 }
 
 ::-webkit-scrollbar-track {
+  background: #e5e7eb;
+}
+
+.dark ::-webkit-scrollbar-track {
   background: #1a1a1a;
 }
 
@@ -55,12 +64,20 @@ body::before {
   width: 100%;
   height: 100%;
   z-index: -2;
-  background: 
+  background:
+    radial-gradient(circle at 20% 50%, rgba(100, 116, 139, 0.4) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(99, 102, 241, 0.3) 0%, transparent 50%),
+    radial-gradient(circle at 40% 80%, rgba(249, 115, 22, 0.2) 0%, transparent 50%),
+    linear-gradient(135deg, #e8edff 0%, #f7f8fc 100%);
+  animation: backgroundShift 20s ease-in-out infinite;
+}
+
+.dark body::before {
+  background:
     radial-gradient(circle at 20% 50%, rgba(26, 27, 46, 0.5) 0%, transparent 50%),
     radial-gradient(circle at 80% 20%, rgba(74, 27, 127, 0.3) 0%, transparent 50%),
     radial-gradient(circle at 40% 80%, rgba(163, 21, 69, 0.2) 0%, transparent 50%),
     linear-gradient(135deg, #0a0a0a 0%, #1a1b2e 100%);
-  animation: backgroundShift 20s ease-in-out infinite;
 }
 
 @keyframes backgroundShift {
@@ -116,6 +133,10 @@ textarea:focus-visible {
 /* Dark theme styles */
 .dark {
   color-scheme: dark;
+}
+
+.light {
+  color-scheme: light;
 }
 
 /* Smooth transitions */


### PR DESCRIPTION
## Summary
- adjust text colors for readability in light mode across sections
- update labels and headings with darker shades when not in dark theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865821b365c8324a26908ac22556dd1