### PR TITLE
Add admin skills and media gallery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Hero from './components/Hero';
 import Experience from './components/Experience';
 import Education from './components/Education';
 import Portfolio from './components/Portfolio';
+import Gallery from './components/Gallery';
 import Skills from './components/Skills';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
@@ -24,7 +25,7 @@ function App() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = ['home', 'experience', 'education', 'portfolio', 'skills', 'contact'];
+      const sections = ['home', 'experience', 'education', 'portfolio', 'gallery', 'skills', 'contact'];
       const scrollPosition = window.scrollY + 100;
 
       for (const section of sections) {
@@ -94,6 +95,7 @@ function App() {
           <Experience />
           <Education />
           <Portfolio />
+          <Gallery />
           <Skills />
           <Contact />
         </main>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useInView } from 'react-intersection-observer';
+import { Play, ExternalLink } from 'lucide-react';
+import { gallery } from '../data/portfolio';
+
+const Gallery: React.FC = () => {
+  const [ref, inView] = useInView({ threshold: 0.1, triggerOnce: true });
+
+  return (
+    <section id="gallery" className="py-20 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto">
+        <motion.div
+          ref={ref}
+          initial={{ opacity: 0, y: 30 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6 }}
+          className="text-center mb-16"
+        >
+          <h2 className="text-4xl sm:text-5xl font-bold mb-4">
+            <span className="bg-gradient-to-r from-green-400 to-emerald-400 bg-clip-text text-transparent">
+              Galería Multimedia
+            </span>
+          </h2>
+          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
+            Un vistazo rápido a mis proyectos fotográficos y audiovisuales
+          </p>
+        </motion.div>
+
+        <div
+          className="grid grid-cols-2 md:grid-cols-4 gap-4 auto-rows-[150px] md:auto-rows-[200px]"
+        >
+          {gallery.map((item, index) => (
+            <motion.a
+              key={item.id}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={inView ? { opacity: 1, scale: 1 } : {}}
+              transition={{ duration: 0.5, delay: index * 0.1 }}
+              className={`relative rounded-xl overflow-hidden group bg-gray-800/50 border border-gray-700/50 backdrop-blur-sm hover:border-green-500/30 transition-all duration-300 ${item.span || ''}`}
+            >
+              <img
+                src={item.thumbnail}
+                alt={item.title}
+                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+              />
+              {item.type === 'video' && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <Play size={32} className="text-white" />
+                </div>
+              )}
+            </motion.a>
+          ))}
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.6, delay: 0.6 }}
+          className="text-center mt-12"
+        >
+          <a
+            href="https://sjaquer-media.example.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-green-600 to-emerald-600 text-white rounded-lg font-medium hover:from-green-700 hover:to-emerald-700 transition-all duration-300 transform hover:scale-105"
+          >
+            <ExternalLink size={18} />
+            Ver portafolio completo
+          </a>
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default Gallery;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ const Header: React.FC<HeaderProps> = ({ activeSection, setActiveSection }) => {
     { id: 'experience', label: 'Experiencia' },
     { id: 'education', label: 'Educación' },
     { id: 'portfolio', label: 'Portafolio' },
+    { id: 'gallery', label: 'Galería' },
     { id: 'skills', label: 'Habilidades' },
     { id: 'contact', label: 'Contacto' }
   ];

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -1,4 +1,4 @@
-import { Experience, Education, Project, Skill } from '../types';
+import { Experience, Education, Project, Skill, GalleryItem } from '../types';
 
 export const experiences: Experience[] = [
 {
@@ -211,5 +211,59 @@ export const skills: Skill[] = [
   { name: 'AWS', category: 'DevOps', proficiency: 85, icon: 'Cloud' },
   { name: 'Docker', category: 'DevOps', proficiency: 80, icon: 'Package' },
   { name: 'Git', category: 'DevOps', proficiency: 95, icon: 'GitBranch' },
-  { name: 'MongoDB', category: 'Base de Datos', proficiency: 85, icon: 'Database' }
+  { name: 'MongoDB', category: 'Base de Datos', proficiency: 85, icon: 'Database' },
+
+  // Administrative
+  { name: 'Planificación Estratégica', category: 'Administrativas', proficiency: 80, icon: 'TrendingUp' },
+  { name: 'Gestión de Proyectos', category: 'Administrativas', proficiency: 85, icon: 'ClipboardList' },
+  { name: 'Análisis Financiero', category: 'Administrativas', proficiency: 75, icon: 'PieChart' },
+  { name: 'Comercio Internacional', category: 'Administrativas', proficiency: 70, icon: 'Globe' },
+  { name: 'Logística y Abastecimiento', category: 'Administrativas', proficiency: 65, icon: 'Truck' },
+  { name: 'Negociación', category: 'Administrativas', proficiency: 80, icon: 'Handshake' }
+];
+
+export const gallery: GalleryItem[] = [
+  {
+    id: '1',
+    title: 'Retrato Corporativo',
+    type: 'photo',
+    thumbnail: 'https://images.pexels.com/photos/3778615/pexels-photo-3778615.jpeg?auto=compress&cs=tinysrgb&w=600',
+    url: 'https://images.pexels.com/photos/3778615/pexels-photo-3778615.jpeg'
+  },
+  {
+    id: '2',
+    title: 'Video Promocional',
+    type: 'video',
+    thumbnail: 'https://images.pexels.com/videos/8561281/free-video-8561281.jpg?auto=compress&cs=tinysrgb&w=600',
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  },
+  {
+    id: '3',
+    title: 'Producto en Estudio',
+    type: 'photo',
+    thumbnail: 'https://images.pexels.com/photos/1111368/pexels-photo-1111368.jpeg?auto=compress&cs=tinysrgb&w=600',
+    url: 'https://images.pexels.com/photos/1111368/pexels-photo-1111368.jpeg'
+  },
+  {
+    id: '4',
+    title: 'Behind the Scenes',
+    type: 'video',
+    thumbnail: 'https://images.pexels.com/photos/2754961/pexels-photo-2754961.jpeg?auto=compress&cs=tinysrgb&w=600',
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  },
+  {
+    id: '5',
+    title: 'Fotografía de Naturaleza',
+    type: 'photo',
+    thumbnail: 'https://images.pexels.com/photos/417173/pexels-photo-417173.jpeg?auto=compress&cs=tinysrgb&w=600',
+    url: 'https://images.pexels.com/photos/417173/pexels-photo-417173.jpeg'
+  },
+  {
+    id: '6',
+    title: 'Corto Experimental',
+    type: 'video',
+    thumbnail: 'https://images.pexels.com/photos/7991379/pexels-photo-7991379.jpeg?auto=compress&cs=tinysrgb&w=600',
+    url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    span: 'md:col-span-2'
+  }
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,3 +44,12 @@ export interface ContactForm {
   subject: string;
   message: string;
 }
+
+export interface GalleryItem {
+  id: string;
+  title: string;
+  type: 'photo' | 'video';
+  thumbnail: string;
+  url: string;
+  span?: string;
+}


### PR DESCRIPTION
## Summary
- extend types with `GalleryItem`
- add administrative skills and sample gallery entries
- create `Gallery` component with bento-like grid
- show new gallery in navigation and layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686587d3b0888324a6a44cb325206a9b