### PR TITLE
Improve skills grid styling

### DIFF
--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import * as Icons from 'lucide-react';
+import { motion } from 'framer-motion';
+import { useInView } from 'react-intersection-observer';
 import { skills as skillsData } from '../data/portfolio';
 import { Skill } from '../types';
 
@@ -49,6 +51,10 @@ const groupedSkills = skillsData.reduce<Record<string, Skill[]>>((acc, skill) =>
   return acc;
 }, {});
 
+Object.keys(groupedSkills).forEach((key) => {
+  groupedSkills[key].sort((a, b) => b.proficiency - a.proficiency);
+});
+
 const getSizeClass = (proficiency: number) => {
   if (proficiency >= 85) return 'w-24 h-24 text-md';
   if (proficiency >= 60) return 'w-20 h-20 text-sm';
@@ -61,47 +67,57 @@ const getGroupScale = (count: number) => {
   return '';
 };
 
-const Skills: React.FC = () => (
-  <section
-    id="skills"
-    className="grid grid-cols-1 md:grid-cols-2 gap-8 px-6 py-16"
-  >
-    {categoryOrder.map((categoria) => {
-      const grupo = groupedSkills[categoria] || [];
-      const borderColor = borderColorMap[categoria] || 'border-primary-500';
-      const scale = getGroupScale(grupo.length);
-      return (
-        <div
-          key={categoria}
-          className={`rounded-2xl border ${borderColor} p-6 bg-dark-900/40 backdrop-blur-md shadow-lg flex flex-col gap-4`}
-        >
-          <h3 className="text-center text-xl font-bold bg-gradient-to-r from-primary-400 to-secondary-500 bg-clip-text text-transparent">
-            {categoria}
-          </h3>
-          <div
-            className="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(70px,1fr))] gap-4 place-items-center"
-          >
-            {grupo.map((skill) => {
-              const Icon = getIconComponent(skill.icon);
-              const sizeClass = getSizeClass(skill.proficiency);
-              const color = colorMap[skill.name] || '#fff';
-              return (
-                <div
-                  key={skill.name}
-                  className={`${sizeClass} ${scale} rounded-2xl flex flex-col items-center justify-center text-center bg-dark-800/50 backdrop-blur-sm hover:scale-105 hover:shadow-xl transition-all duration-300 shadow-md border ${borderColor}`}
-                >
-                  <Icon size={24} style={{ color }} className="mb-1 text-white/90" />
-                  <span className="font-semibold text-white text-xs md:text-sm">
-                    {skill.name}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      );
-    })}
-  </section>
-);
+const Skills: React.FC = () => {
+  const [ref, inView] = useInView({ threshold: 0.1, triggerOnce: true });
+
+  return (
+    <motion.section
+      id="skills"
+      ref={ref}
+      initial={{ opacity: 0, y: 30 }}
+      animate={inView ? { opacity: 1, y: 0 } : {}}
+      transition={{ duration: 0.6 }}
+      className="py-20 px-4 sm:px-6 lg:px-8"
+    >
+      <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6">
+        {categoryOrder.map((categoria) => {
+          const grupo = groupedSkills[categoria] || [];
+          const borderColor = borderColorMap[categoria] || 'border-primary-500';
+          const scale = getGroupScale(grupo.length);
+          return (
+            <motion.div
+              key={categoria}
+              initial={{ opacity: 0, y: 30 }}
+              animate={inView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.6 }}
+              className={`relative rounded-2xl border ${borderColor} p-6 bg-dark-900/40 backdrop-blur-md shadow-md flex flex-col gap-4`}
+            >
+              <h3 className="text-center text-xl font-bold bg-gradient-to-r from-primary-400 to-secondary-500 bg-clip-text text-transparent">
+                {categoria}
+              </h3>
+              <div className="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(70px,1fr))] gap-4 place-items-center">
+                {grupo.map((skill) => {
+                  const Icon = getIconComponent(skill.icon);
+                  const sizeClass = getSizeClass(skill.proficiency);
+                  const color = colorMap[skill.name] || '#fff';
+                  return (
+                    <div
+                      key={skill.name}
+                      className={`${sizeClass} ${scale} rounded-2xl flex flex-col items-center justify-center text-center bg-dark-800/50 backdrop-blur-sm hover:scale-105 hover:shadow-lg transition-all duration-300 shadow-md border ${borderColor} skill-card`}
+                    >
+                      <Icon size={24} style={{ color }} className="mb-1 text-white/90" />
+                      <span className="font-semibold text-white text-xs md:text-sm">{skill.name}</span>
+                      <div className="shine-effect rounded-2xl" />
+                    </div>
+                  );
+                })}
+              </div>
+            </motion.div>
+          );
+        })}
+      </div>
+    </motion.section>
+  );
+};
 
 export default Skills;


### PR DESCRIPTION
## Summary
- redesign Skills section with Bento-style layout
- sort skills by proficiency
- animate entry with framer-motion and add subtle hover effects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3b8eda088324820ae2522e474aad